### PR TITLE
Corrige o bug de validação de email

### DIFF
--- a/src/repository/UserRepository.ts
+++ b/src/repository/UserRepository.ts
@@ -16,13 +16,13 @@ export interface IUserRepository {
 export default class UserRepository implements IUserRepository {
   async createUser(newUserObj: IDbUser): Promise<void> {
     await prisma.user.create({
-      data: newUserObj,
+      data: { ...newUserObj, email: newUserObj.email.toLowerCase() },
     });
   }
 
   async findUserByEmail(email: string): Promise<IDbUser | null> {
     return await prisma.user.findUnique({
-      where: { email },
+      where: { email: email.toLowerCase() },
     });
   }
 

--- a/test/unity/src/repository/UserRepository.test.ts
+++ b/test/unity/src/repository/UserRepository.test.ts
@@ -31,7 +31,7 @@ describe("src/repository/UserRepository.ts", () => {
       await userRepository.createUser(userObj);
 
       expect(prisma.user.create).toHaveBeenCalledWith({
-        data: userObj,
+        data: { ...userObj, email: userObj.email.toLowerCase() },
       });
     });
 
@@ -93,7 +93,7 @@ describe("src/repository/UserRepository.ts", () => {
       await userRepository.findUserByEmail(nonExistentEmail);
 
       expect(prisma.user.findUnique).toHaveBeenCalledWith({
-        where: { email: nonExistentEmail },
+        where: { email: nonExistentEmail.toLowerCase() },
       });
     });
 


### PR DESCRIPTION
Agora somente email em caixa baixa são armazenados no banco de dados. 

Adicionado `.toLowerCase()` nos métodos `createUser` e `findUserByEmail` do `UserRepository.ts` e em seus respectivos testes. 