### PR TITLE
Altera o nome do schema ShoppingList

### DIFF
--- a/prisma/migrations/20250505164455_rename_shopping_list_to_products/migration.sql
+++ b/prisma/migrations/20250505164455_rename_shopping_list_to_products/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the `ShoppingList` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ShoppingList" DROP CONSTRAINT "ShoppingList_userId_fkey";
+
+-- DropTable
+DROP TABLE "ShoppingList";
+
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" TEXT NOT NULL,
+    "productName" TEXT NOT NULL,
+    "productPrice" DOUBLE PRECISION NOT NULL,
+    "productQuantity" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Product" ADD CONSTRAINT "Product_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,7 +21,7 @@ model User {
   createdAt          DateTime             @default(now())
   SessionToken       SessionToken[]
   ResetPasswordToken ResetPasswordToken[]
-  ShoppingList       ShoppingList[]
+  ProductList        Product[]
 }
 
 model SessionToken {
@@ -42,7 +42,7 @@ model ResetPasswordToken {
   createdAt DateTime @default(now())
 }
 
-model ShoppingList {
+model Product {
   id              String   @id @default(uuid())
   productName     String
   productPrice    Float

--- a/src/repository/ShoppingListRepository.ts
+++ b/src/repository/ShoppingListRepository.ts
@@ -27,32 +27,32 @@ export interface IShoppingListRepository {
 
 export default class ShoppingListRepository implements IShoppingListRepository {
   async create(newProductObj: INewProduct): Promise<void> {
-    await prisma.shoppingList.create({
+    await prisma.product.create({
       data: newProductObj,
     });
   }
 
   async findAll(userId: string): Promise<IDbProduct[] | []> {
-    return await prisma.shoppingList.findMany({
+    return await prisma.product.findMany({
       where: { userId },
     });
   }
 
   async findById(productId: string): Promise<IDbProduct | null> {
-    return await prisma.shoppingList.findUnique({
+    return await prisma.product.findUnique({
       where: { id: productId },
     });
   }
 
   async update(productId: string, product: IUpdateProduct): Promise<void> {
-    await prisma.shoppingList.update({
+    await prisma.product.update({
       where: { id: productId },
       data: product,
     });
   }
 
   async deleteById(productId: string) {
-    await prisma.shoppingList.delete({
+    await prisma.product.delete({
       where: { id: productId },
     });
   }

--- a/test/unity/src/repository/ShoppingListRepository.test.ts
+++ b/test/unity/src/repository/ShoppingListRepository.test.ts
@@ -3,7 +3,7 @@ import ShoppingListRepository from "@/repository/ShoppingListRepository";
 
 jest.mock("../../../../src/lib/prisma", () => ({
   prisma: {
-    shoppingList: {
+    product: {
       create: jest.fn(),
       findMany: jest.fn(),
       findUnique: jest.fn(),
@@ -29,11 +29,11 @@ describe("src/repository/ShoppingListRepository.ts", () => {
         userId: "123456",
       };
 
-      (prisma.shoppingList.create as jest.Mock).mockResolvedValue(undefined);
+      (prisma.product.create as jest.Mock).mockResolvedValue(undefined);
 
       await shoppingListRepository.create(newProduct);
 
-      expect(prisma.shoppingList.create).toHaveBeenCalledWith({
+      expect(prisma.product.create).toHaveBeenCalledWith({
         data: newProduct,
       });
     });
@@ -51,11 +51,11 @@ describe("src/repository/ShoppingListRepository.ts", () => {
         },
       ];
 
-      (prisma.shoppingList.findMany as jest.Mock).mockResolvedValue(dbProducts);
+      (prisma.product.findMany as jest.Mock).mockResolvedValue(dbProducts);
 
       const result = await shoppingListRepository.findAll("123abc");
 
-      expect(prisma.shoppingList.findMany).toHaveBeenCalledWith({
+      expect(prisma.product.findMany).toHaveBeenCalledWith({
         where: { userId: "123abc" },
       });
       expect(result).toEqual(dbProducts);
@@ -72,11 +72,11 @@ describe("src/repository/ShoppingListRepository.ts", () => {
         updatedAt: new Date(),
       };
 
-      (prisma.shoppingList.findUnique as jest.Mock).mockResolvedValue(dbProduct);
+      (prisma.product.findUnique as jest.Mock).mockResolvedValue(dbProduct);
 
       const result = await shoppingListRepository.findById("098zxc");
 
-      expect(prisma.shoppingList.findUnique).toHaveBeenCalledWith({
+      expect(prisma.product.findUnique).toHaveBeenCalledWith({
         where: { id: "098zxc" },
       });
 
@@ -90,22 +90,22 @@ describe("src/repository/ShoppingListRepository.ts", () => {
         productQuantity: 1,
       };
 
-      (prisma.shoppingList.update as jest.Mock).mockResolvedValue(undefined);
+      (prisma.product.update as jest.Mock).mockResolvedValue(undefined);
 
       await shoppingListRepository.update("098zxc", updatedProduct);
 
-      expect(prisma.shoppingList.update).toHaveBeenCalledWith({
+      expect(prisma.product.update).toHaveBeenCalledWith({
         where: { id: "098zxc" },
         data: updatedProduct,
       });
     });
 
     test("Should delete product", async () => {
-      (prisma.shoppingList.delete as jest.Mock).mockResolvedValue(undefined);
+      (prisma.product.delete as jest.Mock).mockResolvedValue(undefined);
 
       await shoppingListRepository.deleteById("098zxc");
 
-      expect(prisma.shoppingList.delete).toHaveBeenCalledWith({
+      expect(prisma.product.delete).toHaveBeenCalledWith({
         where: { id: "098zxc" },
       });
     });
@@ -113,22 +113,22 @@ describe("src/repository/ShoppingListRepository.ts", () => {
 
   describe("Failure Cases", () => {
     test("Should return a empty array if user don't have products", async () => {
-      (prisma.shoppingList.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.product.findMany as jest.Mock).mockResolvedValue([]);
 
       const result = await shoppingListRepository.findAll("123abc");
 
-      expect(prisma.shoppingList.findMany).toHaveBeenCalledWith({
+      expect(prisma.product.findMany).toHaveBeenCalledWith({
         where: { userId: "123abc" },
       });
       expect(result).toEqual([]);
     });
 
     test("Should return null if product don't exist when find by ID", async () => {
-      (prisma.shoppingList.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.product.findUnique as jest.Mock).mockResolvedValue(null);
 
       const result = await shoppingListRepository.findById("unexistent-id");
 
-      expect(prisma.shoppingList.findUnique).toHaveBeenCalledWith({
+      expect(prisma.product.findUnique).toHaveBeenCalledWith({
         where: { id: "unexistent-id" },
       });
 


### PR DESCRIPTION
Altera o nome do schama do prisma `ShoppingList` para `Product` e cria nova migration.
Alteração feita no `schema.prisma`, `ShoppingListRepository.test.ts` e `ShoppingListRepository.ts`. 