### PR TITLE
Melhora a segurança do endpoint `/api/v1/product/delete/one`

### DIFF
--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -31,7 +31,7 @@ export default function Product({ id, userId, productName, productPrice, product
 
   async function handleDeleteProduct() {
     try {
-      await fetchDeleteProduct(id, userId);
+      await fetchDeleteProduct(id);
       mutate(`/api/v1/product/list-products/${userId}`);
 
       SetIsDialogOpen(false);

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -110,11 +110,9 @@ export function useFetch() {
     return response;
   }
 
-  async function fetchDeleteProduct(productId: string, userId: string) {
-    await fetch(`/api/v1/product/delete-product/${productId}`, {
+  async function fetchDeleteProduct(productId: string) {
+    await fetch(`/api/v1/product/delete/one/${productId}`, {
       method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ userId }),
     });
   }
 

--- a/src/pages/api/v1/product/delete/one/[productId].ts
+++ b/src/pages/api/v1/product/delete/one/[productId].ts
@@ -1,3 +1,4 @@
+import getUserIdFromRequest from "@/lib/auth";
 import { InternalServerError, ProductServiceError } from "@/lib/CustomErrors";
 import ShoppingListRepository from "@/repository/ShoppingListRepository";
 import UserRepository from "@/repository/UserRepository";
@@ -13,11 +14,15 @@ export default async function deleteProduct(req: NextApiRequest, res: NextApiRes
     return res.status(405).json({ message: "Method not allowed." });
   }
 
+  const userId = await getUserIdFromRequest(req);
+  if (!userId) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
   try {
     const { productId } = req.query;
-    const { userId } = req.body;
 
-    await shoppingListService.deleteProduct(productId as string, userId);
+    await shoppingListService.deleteProduct(productId as string, userId as string);
 
     return res.status(200).json({ message: "Product deleted." });
   } catch (error) {

--- a/src/repository/ShoppingListRepository.ts
+++ b/src/repository/ShoppingListRepository.ts
@@ -22,7 +22,7 @@ export interface IShoppingListRepository {
   findAll(userId: string): Promise<IDbProduct[] | []>;
   findById(productId: string): Promise<IDbProduct | null>;
   update(productId: string, product: IUpdateProduct): Promise<void>;
-  deleteById(productId: string): Promise<void>;
+  deleteById(productId: string, userId: string): Promise<void>;
   deleteSelected(productIds: string[], userId: string): Promise<void>;
 }
 
@@ -52,9 +52,12 @@ export default class ShoppingListRepository implements IShoppingListRepository {
     });
   }
 
-  async deleteById(productId: string) {
+  async deleteById(productId: string, userId: string) {
     await prisma.product.delete({
-      where: { id: productId },
+      where: {
+        id: productId,
+        userId: userId,
+      },
     });
   }
 

--- a/src/services/ShoppingListService.ts
+++ b/src/services/ShoppingListService.ts
@@ -131,7 +131,7 @@ export default class ShoppingListService {
         throw new ProductServiceError("Permision Denied.", "Permision Denied.", 403, false);
       }
 
-      await this.shoppingListRepository.deleteById(productId);
+      await this.shoppingListRepository.deleteById(productId, userId);
     } catch (error) {
       console.error("Error during delete one product: ", error);
 

--- a/test/unity/src/repository/ShoppingListRepository.test.ts
+++ b/test/unity/src/repository/ShoppingListRepository.test.ts
@@ -104,10 +104,13 @@ describe("src/repository/ShoppingListRepository.ts", () => {
     test("Should delete one product", async () => {
       (prisma.product.delete as jest.Mock).mockResolvedValue(undefined);
 
-      await shoppingListRepository.deleteById("098zxc");
+      await shoppingListRepository.deleteById("098zxc", "123abc");
 
       expect(prisma.product.delete).toHaveBeenCalledWith({
-        where: { id: "098zxc" },
+        where: {
+          id: "098zxc",
+          userId: "123abc",
+        },
       });
     });
 

--- a/test/unity/src/services/ShoppingListService.test.ts
+++ b/test/unity/src/services/ShoppingListService.test.ts
@@ -387,7 +387,7 @@ describe("src/services/ShoppingListService.ts", () => {
 
         await expect(shoppingListService.deleteProduct("098zxc", "123abc")).resolves.toBeUndefined();
         expect(mockShoppingListRepository.findById).toHaveBeenCalledWith("098zxc");
-        expect(mockShoppingListRepository.deleteById).toHaveBeenCalledWith("098zxc");
+        expect(mockShoppingListRepository.deleteById).toHaveBeenCalledWith("098zxc", "123abc");
       });
     });
 


### PR DESCRIPTION
Corrige falha de segurança no enpoint `/api/v1/product/delete/one`, onde o **userId** era obtido pelo **body** da requisição. 