### PR TITLE
fix: improving `authinput` component to be more accessibility and fle…

### DIFF
--- a/src/components/AuthInput.tsx
+++ b/src/components/AuthInput.tsx
@@ -8,21 +8,21 @@ const montserrat = Montserrat({
 });
 
 interface AuthInputProps extends InputHTMLAttributes<HTMLInputElement> {
-  Icon: ElementType;
+  Icon?: ElementType;
 }
 
 export default function AuthInput({ Icon, ...rest }: AuthInputProps) {
   return (
-    <div
+    <label
       className={`${montserrat.variable} flex justify-center items-center p-1 border-b
       bg-primaryLightBG border-zinc-700 focus-within:border-zinc-400 hover:border-zinc-400 text-lightTxt 
       dark:bg-primaryDarkBG dark:border-zinc-500 dark:text-darkTxt`}
     >
-      <Icon className="text-xl mr-2" />
+      {Icon && <Icon className="text-xl mr-2" />}
       <input
         className="w-full outline-none font-[500] placeholder-zinc-400 placeholder:font-[500] bg-primaryLightBG dark:bg-primaryDarkBG dark:placeholder-zinc-600"
         {...rest}
-      ></input>
-    </div>
+      />
+    </label>
   );
 }


### PR DESCRIPTION
The component is using a regular `div`, but it can use a `label` instead to improve accessibility and _SEO_, because it improves _HTML_ semantics too.

![Image](https://github.com/user-attachments/assets/05e01558-2d57-431b-964e-cdc4ff7b6f6b)

![Image](https://github.com/user-attachments/assets/12be1cae-485b-4a8c-81b7-df5bbff3b4d7)

Furthermore, the component requires an icon component, but it can be more flexible and turn it optional.